### PR TITLE
Add 32-bit vkd3d

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -772,6 +772,27 @@ modules:
       - /lib/vkd3d/prefix
 
 
+  - name: vkd3d-32bit
+    subdir: vkd3d
+    build-options:
+      ldflags: >-
+        -L/usr/lib/sdk/mingw-w64/i686-w64-mingw32/lib
+        -L/app/share/steam/compatibilitytools.d/Proton-GE/lib32/wine/i386-windows
+      ldflags-override: true
+      config-opts:
+        - --host=i686-w64-mingw32
+      env:
+        CC: ccache i686-w64-mingw32-gcc
+        LD: i686-w64-mingw32-ld
+      prefix: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/vkd3d/prefix
+    config-opts: *vkd3d-config-opts
+    post-install:
+      - mv -v ${FLATPAK_DEST}/lib32/vkd3d/{prefix/bin/,}libvkd3d-shader-1.dll
+    sources: *vkd3d-sources
+    cleanup:
+      - /lib32/vkd3d/prefix
+
+
   - name: vkd3d-proton
     subdir: vkd3d-proton
     buildsystem: meson

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -750,14 +750,14 @@ modules:
     subdir: vkd3d
     build-options:
       ldflags: >-
-        -L/usr/lib/sdk/mingw-w64/x86_64-w64-mingw32/lib
-        -L/app/share/steam/compatibilitytools.d/Proton-GE/lib/wine/x86_64-windows
+        -L/run/build/vkd3d/wine/dlls/vulkan-1
       ldflags-override: true
       config-opts:
         - --host=x86_64-w64-mingw32
       env:
         CC: ccache x86_64-w64-mingw32-gcc
         LD: x86_64-w64-mingw32-ld
+        LIBDIR_WINE_PE: /app/share/steam/compatibilitytools.d/Proton-GE/lib/wine/x86_64-windows
       prefix: /app/share/steam/compatibilitytools.d/Proton-GE/lib/vkd3d/prefix
     config-opts: &vkd3d-config-opts
       - --disable-doxygen-doc
@@ -768,6 +768,9 @@ modules:
       - mv -v ${FLATPAK_DEST}/lib/vkd3d/{prefix/bin/,}libvkd3d-shader-1.dll
     sources: &vkd3d-sources
       - *proton_source
+      - type: shell
+        commands:
+          - install -D $LIBDIR_WINE_PE/vulkan-1.dll -t wine/dlls/vulkan-1/
     cleanup:
       - /lib/vkd3d/prefix
 
@@ -776,14 +779,14 @@ modules:
     subdir: vkd3d
     build-options:
       ldflags: >-
-        -L/usr/lib/sdk/mingw-w64/i686-w64-mingw32/lib
-        -L/app/share/steam/compatibilitytools.d/Proton-GE/lib32/wine/i386-windows
+        -L/run/build/vkd3d-32bit/wine/dlls/vulkan-1
       ldflags-override: true
       config-opts:
         - --host=i686-w64-mingw32
       env:
         CC: ccache i686-w64-mingw32-gcc
         LD: i686-w64-mingw32-ld
+        LIBDIR_WINE_PE: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/wine/i386-windows
       prefix: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/vkd3d/prefix
     config-opts: *vkd3d-config-opts
     post-install:


### PR DESCRIPTION
vkd3d fails to link with static `libvulkan-1.a`, but links successfully links with dynamic `vulkan-1.dll`. We can alter the vkd3d module environment in a way that it can only link with the dynamic lib (this seems to match the upstream case, but not sure).

Hopefully fixes #57 and #53 for good.