### PR TITLE
Add metadata for update checker to wine-mono dependency

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -902,6 +902,10 @@ modules:
         url: https://github.com/madewokherd/wine-mono/releases/download/wine-mono-7.1.5/wine-mono-7.1.5-x86.tar.xz
         sha256: cb03854b5d868b2d0912da42e01536bb673e009ed5263f4eeb8836a2a9c36f43
         strip-components: 0
+        x-checker-data:
+          type: anitya
+          project-id: 7641
+          url-template: https://github.com/madewokherd/wine-mono/releases/download/wine-mono-$version/wine-mono-$version-x86.tar.xz
 
 
   - name: wine-gecko-bin


### PR DESCRIPTION
Adds metadata for @flathubbot to create pull requests to keep update wine-mono based on [anitya](https://release-monitoring.org/project/7641/).
I don't know if this works automatically or requires additional setup.