### PR TITLE
Convert release names to semver

### DIFF
--- a/files/proton/source.yaml
+++ b/files/proton/source.yaml
@@ -5,6 +5,6 @@ sha256: 1fec464fb45711fc62ceebfa344c02f083ea14d047a779d4b1a95b29782c243b
 x-checker-data:
   type: json
   url: https://api.github.com/repos/lctrs/proton-ge-custom-tarball-maker/releases/latest
-  version-query: .tag_name
+  version-query: .tag_name | sub("^GE-Proton"; "") | sub("-"; ".")
   url-query: .assets[] | select(.name=="proton-ge-custom-src.tar.xz") | .browser_download_url
   is-main-source: true


### PR DESCRIPTION
Building GE-Proton7-10-1 (#83) fails as flatpak-build considers `GE-Proton7-9-1` a higher version number than `GE-Proton7-10-1`.
```
com.valvesoftware.Steam.CompatibilityTool.Proton-GE: AppData problem: tag-invalid : <release> versions are not in order [GE-Proton7-10-1 before GE-Proton7-9-1]
```

This merge request modifies the release version name by removing `GE-Proton` from the beginning and replacing hyphens `-` with full stops `.` to better adhere to semantic versioning.

The code is based on [this search](https://github.com/search?q=org%3Aflathub+version-query&type=code) and is untested.
I don't know if there is a better solution.