### PR TITLE
Fix release name to semver conversion

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.metainfo.xml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.metainfo.xml
@@ -8,7 +8,6 @@
   <project_license>BSD-3-Clause and LGPL-2.1 and zlib-acknowledgement and Zlib and OFL-1.1 and MIT and MPL-2.0 and LicenseRef-proprietary</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
-    <release version="GE-Proton7-9-1" date="2022-03-09"/>
-    <release version="GE-Proton7-8-2" date="2022-03-06"/>
+    <release version="7.10.2" date="2022-03-20"/>
   </releases>
 </component>

--- a/files/proton/source.yaml
+++ b/files/proton/source.yaml
@@ -1,7 +1,7 @@
 type: archive
-url: https://github.com/Lctrs/proton-ge-custom-tarball-maker/releases/download/GE-Proton7-9-1/proton-ge-custom-src.tar.xz
+url: https://github.com/Lctrs/proton-ge-custom-tarball-maker/releases/download/GE-Proton7-10-2/proton-ge-custom-src.tar.xz
 strip-components: 0
-sha256: 1fec464fb45711fc62ceebfa344c02f083ea14d047a779d4b1a95b29782c243b
+sha256: 42185f697f8f77f8b8bc0fd0e73df00576f4fee3baf34495c52aaca732eeaa93
 x-checker-data:
   type: json
   url: https://api.github.com/repos/lctrs/proton-ge-custom-tarball-maker/releases/latest

--- a/files/proton/source.yaml
+++ b/files/proton/source.yaml
@@ -5,6 +5,6 @@ sha256: 1fec464fb45711fc62ceebfa344c02f083ea14d047a779d4b1a95b29782c243b
 x-checker-data:
   type: json
   url: https://api.github.com/repos/lctrs/proton-ge-custom-tarball-maker/releases/latest
-  version-query: .tag_name | sub("^GE-Proton"; "") | sub("-"; ".")
+  version-query: .tag_name | sub("^GE-Proton"; "") | gsub("-"; ".")
   url-query: .assets[] | select(.name=="proton-ge-custom-src.tar.xz") | .browser_download_url
   is-main-source: true


### PR DESCRIPTION
My previous fix (#84) used `sub` which only replaced the first hyphen in the version number producing `7.10-2`.
This merge request uses `gsub` which replaces all hyphens with full stops producing `7.10.2`.