### PR TITLE
Fix broken build and update

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.metainfo.xml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.metainfo.xml
@@ -8,6 +8,7 @@
   <project_license>BSD-3-Clause and LGPL-2.1 and zlib-acknowledgement and Zlib and OFL-1.1 and MIT and MPL-2.0 and LicenseRef-proprietary</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
+    <release version="7.42-1" date="2022-12-16"/>
     <release version="7.36-1" date="2022-10-03"/>
     <release version="7.35-1" date="2022-09-19"/>
     <release version="7.33-1" date="2022-09-12"/>

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -613,8 +613,8 @@ modules:
       - cp -a wine-mono-*/ ${FLATPAK_DEST}/share/wine/mono/
     sources:
       - type: archive
-        url: https://github.com/madewokherd/wine-mono/releases/download/wine-mono-7.3.1/wine-mono-7.3.1-x86.tar.xz
-        sha256: 55ca808868599b1d8ad53b222b8cb26fd96fa818c511163e361238025c76e9fe
+        url: https://github.com/madewokherd/wine-mono/releases/download/wine-mono-7.4.0/wine-mono-7.4.0-x86.tar.xz
+        sha256: 9249ece664bcf2fecb1308ea1d2542c72923df9fe3df891986f137b2266a9ba3
         strip-components: 0
         x-checker-data:
           type: html
@@ -668,6 +668,7 @@ modules:
     sources:
       - *proton_source
     modules:
+
       - name: fontforge
         buildsystem: cmake-ninja
         builddir: true

--- a/files/proton/source.yaml
+++ b/files/proton/source.yaml
@@ -1,7 +1,7 @@
 type: archive
-url: https://github.com/Lctrs/proton-ge-custom-tarball-maker/releases/download/GE-Proton7-36-1/proton-ge-custom-src.tar.xz
+url: https://github.com/Lctrs/proton-ge-custom-tarball-maker/releases/download/GE-Proton7-42-1/proton-ge-custom-src.tar.xz
 strip-components: 0
-sha256: a5edae73d32f0614357e14a37e7a83e66ee0459e538f79a2bca0141f0d3b423d
+sha256: fee4e8e298b56eee120ea68115b156ffa611192e86a215d755e6e56a3e3d7ec1
 x-checker-data:
   type: json
   url: https://api.github.com/repos/lctrs/proton-ge-custom-tarball-maker/releases/latest


### PR DESCRIPTION
The automatic updates from flathubbot are failing with the following errors (copied from https://buildbot.flathub.org/#/builders/37/builds/1431):

```
ERROR   src.manifest: Failed to check archive wine-mono-bin/wine-mono-7.4.0-x86.tar.xz with HTMLChecker: Error substituting template: 'parent_major'
INFO    src.manifest: Started check [29/30] file wine-gecko-bin/wine-gecko-2.47.3-x86.tar.xz (from com.valvesoftware.Steam.CompatibilityTool.Proton-GE.yml)
ERROR   src.manifest: Failed to check file wine-gecko-bin/wine-gecko-2.47.3-x86.tar.xz with HTMLChecker: Error substituting template: 'parent_major'
INFO    src.manifest: Started check [30/30] file wine-gecko-bin/wine-gecko-2.47.3-x86_64.tar.xz (from com.valvesoftware.Steam.CompatibilityTool.Proton-GE.yml)
ERROR   src.manifest: Failed to check file wine-gecko-bin/wine-gecko-2.47.3-x86_64.tar.xz with HTMLChecker: Error substituting template: 'parent_major'
WARNING src.main: Check finished with 3 error(s)
```

I think this is caused by the version query returning "7.42-1" instead of "7.42.1". I think this means that the URL will substitute to "https://raw.githubusercontent.com/GloriousEggroll/proton-ge-custom/GE-Proton7-42-1/Makefile.in" instead of "https://raw.githubusercontent.com/GloriousEggroll/proton-ge-custom/GE-Proton7-42/Makefile.in". I am not 100% sure if that is what is happening, as the logs do not say how it is failing, and I am not sure where to even find documentation on $parent_major, $parent_minor, etc.. This seems to be fixed by doing a greedy substitute.

There is also another issue where vkd3d-proton would fail at configure step because of `enable_d3d12` option, which seems to be removed as of the following commit: https://github.com/HansKristian-Work/vkd3d-proton/commit/065f2fc6484cfa49f6dd4f0b0c6f3eca58f3cc32.

Feel free to modify this pull request or only accept parts of it or whatever.