### PR TITLE
fix steamexe compile flags

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -259,6 +259,7 @@ modules:
       - -I../wine/include
       - -I../openvr/headers
       - -lsteam_api
+      - -lshlwapi
       - -lmsi
       - -lole32
       - -ldl


### PR DESCRIPTION
Upstream added the shlwapi library dependency:

> https://github.com/GloriousEggroll/proton-ge-custom/blame/60c0506d01b6a26c6685713c36ccbe904d378b13/Makefile.in#L491