### PR TITLE
fix vrclient wine include directory

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -317,6 +317,7 @@ modules:
       - -I${FLATPAK_DEST}/include
       - -I${FLATPAK_DEST}/include/wine
       - -I${FLATPAK_DEST}/include/wine/windows
+      - -I../../wine/include
       - -I.
       - -I..
       - --dll


### PR DESCRIPTION
The vrclient build sits one directory deeper than most other processes, thus the two parent directories. Apart from that, Proton 8-1 has introduced several code changes which now require unixlib.h which needs to be provided by the locally compiled wine, thus the specific include.

This fixes compilation of vrclient with the new proton version (#150).