### PR TITLE
Proton8-3 fixes

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -377,6 +377,7 @@ modules:
       - -lopenxr_loader
       - -ldxgi
       - -lvulkan
+      - -ldl
       - --dll
       - .
     build-commands:

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -259,6 +259,7 @@ modules:
       - -I../wine/include
       - -I../openvr/headers
       - -lsteam_api
+      - -lshlwapi
       - -lmsi
       - -lole32
       - -ldl

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -318,6 +318,7 @@ modules:
       - -I${FLATPAK_DEST}/include
       - -I${FLATPAK_DEST}/include/wine
       - -I${FLATPAK_DEST}/include/wine/windows
+      - -I../../wine/include
       - -I.
       - -I..
       - --dll

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -91,7 +91,7 @@ modules:
       - *proton_source
 
 
-  - name: vkd3d-d3d12
+  - name: vkd3d
     subdir: vkd3d
     build-options:
       arch:
@@ -107,7 +107,7 @@ modules:
     sources:
       - *proton_source
 
-  - name: vkd3d-d3d12-32bit
+  - name: vkd3d-32bit
     subdir: vkd3d
     only-arches:
       - x86_64
@@ -416,7 +416,7 @@ modules:
 
 # TODO: build vkd3d against cross-compiled Vulkan-Loader instead of Wine vulkan lib
 
-  - name: vkd3d
+  - name: vkd3d-wine
     subdir: vkd3d
     build-options:
       arch:
@@ -444,7 +444,7 @@ modules:
     cleanup:
       - /lib/vkd3d/prefix
 
-  - name: vkd3d-32bit
+  - name: vkd3d-wine-32bit
     subdir: vkd3d
     build-options:
       ldflags: >-

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -26,7 +26,7 @@ build-options:
     FLATPAK_LIBDIR_WINE_ELF: /app/share/steam/compatibilitytools.d/Proton-GE/lib/wine/x86_64-unix
     FLATPAK_LIBDIR_WINE_PE: /app/share/steam/compatibilitytools.d/Proton-GE/lib/wine/x86_64-windows
   cflags: &optflags -O2 -pipe -march=nocona -mtune=core-avx2 -mfpmath=sse -fwrapv
-    -fno-strict-aliasing
+    -fno-strict-aliasing -mcmodel=small
   cflags-override: true
   cxxflags: *optflags
   cxxflags-override: true

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -643,15 +643,11 @@ modules:
   - name: fonts
     buildsystem: simple
     build-commands:
-      - |
-        cat <<EOF > Makefile
-        SRCDIR     := $(pwd)
-        BUILD_NAME := proton-flatpak
-        include \$(SRCDIR)/Makefile.in
-        EOF
-      - make fonts
-      - find obj-fonts/ -xtype f \( -name "*.otf" -o -name "*.ttf" \) -ls -exec install
-        -Dm0644 -t ${FLATPAK_DEST}/share/fonts/ {} \;
+      - make -f Makefile.in "CURDIR=$(pwd)" "SRCDIR=$(pwd)" BUILD_NAME=proton-flatpak CONTAINER=1 fonts
+      - >-
+          find obj-fonts/
+          -xtype f \( -name "*.otf" -o -name "*.ttf" \)
+          -ls -exec install -Dm0644 -t ${FLATPAK_DEST}/share/fonts/ {} \;
     sources:
       - *proton_source
     modules:

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -432,6 +432,7 @@ modules:
       prefix: /app/share/steam/compatibilitytools.d/Proton-GE/lib/vkd3d/prefix
     config-opts: *vkd3d-config-opts
     post-install:
+      - mv -v ${FLATPAK_DEST}/lib/vkd3d/{prefix/bin/,}libvkd3d-1.dll
       - mv -v ${FLATPAK_DEST}/lib/vkd3d/{prefix/bin/,}libvkd3d-shader-1.dll
     sources: &vkd3d-sources
       - *proton_source
@@ -459,6 +460,7 @@ modules:
       prefix: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/vkd3d/prefix
     config-opts: *vkd3d-config-opts
     post-install:
+      - mv -v ${FLATPAK_DEST}/lib32/vkd3d/{prefix/bin/,}libvkd3d-1.dll
       - mv -v ${FLATPAK_DEST}/lib32/vkd3d/{prefix/bin/,}libvkd3d-shader-1.dll
     sources: *vkd3d-sources
     cleanup:

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -11,6 +11,75 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.toolchain-i386
   - org.freedesktop.Sdk.Extension.mingw-w64
 
+x-var:
+  - &proton_source files/proton/source.yaml
+  - &optflags >-
+    -O2
+    -pipe
+    -march=nocona
+    -mtune=core-avx2
+    -mfpmath=sse
+    -fwrapv
+    -fno-strict-aliasing
+    -mcmodel=small
+  - &optflags32 >-
+    -O2
+    -pipe
+    -march=nocona
+    -mtune=core-avx2
+    -mfpmath=sse
+    -fwrapv
+    -fno-strict-aliasing
+    -mstackrealign
+  - &mingw-ldflags-64 >-
+    -static-libgcc
+    -Wl,--file-alignment,4096
+    -L/app/share/steam/compatibilitytools.d/Proton-GE/lib
+    -L/app/lib
+  - &mingw-ldflags-32 >-
+    -static-libgcc
+    -Wl,--file-alignment,4096
+    -L/app/share/steam/compatibilitytools.d/Proton-GE/lib32
+    -L/app/lib32
+  - &mingw-64-opts
+    ldflags: *mingw-ldflags-64
+    ldflags-override: true
+    env:
+      CC: ccache x86_64-w64-mingw32-gcc
+      LD: x86_64-w64-mingw32-ld
+      WIDL: x86_64-w64-mingw32-widl
+  - &mingw-32-opts
+    # XXX: build-options.arch.*.env overrides build-options.env
+    # so we can't easily use compat_i386_opts anchor here
+    cflags: *optflags32
+    cflags-override: true
+    cxxflags: *optflags32
+    cxxflags-override: true
+    ldflags: *mingw-ldflags-32
+    ldflags-override: true
+    env:
+      CC: ccache i686-w64-mingw32-gcc
+      LD: i686-w64-mingw32-ld
+      WIDL: i686-w64-mingw32-widl
+  - &compat_i386_opts
+    ldflags: -L/app/share/steam/compatibilitytools.d/Proton-GE/lib32 -L/app/lib32
+    prepend-path: /app/share/steam/compatibilitytools.d/Proton-GE/bin32
+    append-path: /usr/lib/sdk/toolchain-i386/bin
+    env:
+      CC: ccache i686-unknown-linux-gnu-gcc
+      CXX: ccache i686-unknown-linux-gnu-g++
+      PKG_CONFIG_PATH: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/pkgconfig:/app/lib32/pkgconfig:/app/share/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/share/pkgconfig
+      LD_RUN_PATH: /app/share/steam/compatibilitytools.d/Proton-GE/lib32
+      FLATPAK_LIBDIR: /app/share/steam/compatibilitytools.d/Proton-GE/lib32
+      FLATPAK_LIBDIR_WINE: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/wine
+      FLATPAK_LIBDIR_WINE_ELF: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/wine/i386-unix
+      FLATPAK_LIBDIR_WINE_PE: &lib32_wine_pe /app/share/steam/compatibilitytools.d/Proton-GE/lib32/wine/i386-windows
+    libdir: /app/share/steam/compatibilitytools.d/Proton-GE/lib32
+    cflags: *optflags32
+    cflags-override: true
+    cxxflags: *optflags32
+    cxxflags-override: true
+
 build-options:
   prefix: /app/share/steam/compatibilitytools.d/Proton-GE
   append-path: /usr/lib/sdk/mingw-w64/bin:/app/share/steam/compatibilitytools.d/Proton-GE/bin
@@ -25,33 +94,10 @@ build-options:
     FLATPAK_LIBDIR_WINE: /app/share/steam/compatibilitytools.d/Proton-GE/lib/wine
     FLATPAK_LIBDIR_WINE_ELF: /app/share/steam/compatibilitytools.d/Proton-GE/lib/wine/x86_64-unix
     FLATPAK_LIBDIR_WINE_PE: /app/share/steam/compatibilitytools.d/Proton-GE/lib/wine/x86_64-windows
-  cflags: &optflags -O2 -pipe -march=nocona -mtune=core-avx2 -mfpmath=sse -fwrapv
-    -fno-strict-aliasing -mcmodel=small
+  cflags: *optflags
   cflags-override: true
   cxxflags: *optflags
   cxxflags-override: true
-
-x-compat-i386-opts: &compat_i386_opts
-  ldflags: -L/app/share/steam/compatibilitytools.d/Proton-GE/lib32 -L/app/lib32
-  prepend-path: /app/share/steam/compatibilitytools.d/Proton-GE/bin32
-  append-path: /usr/lib/sdk/toolchain-i386/bin
-  env:
-    CC: ccache i686-unknown-linux-gnu-gcc
-    CXX: ccache i686-unknown-linux-gnu-g++
-    PKG_CONFIG_PATH: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/pkgconfig:/app/lib32/pkgconfig:/app/share/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/share/pkgconfig
-    LD_RUN_PATH: /app/share/steam/compatibilitytools.d/Proton-GE/lib32
-    FLATPAK_LIBDIR: /app/share/steam/compatibilitytools.d/Proton-GE/lib32
-    FLATPAK_LIBDIR_WINE: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/wine
-    FLATPAK_LIBDIR_WINE_ELF: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/wine/i386-unix
-    FLATPAK_LIBDIR_WINE_PE: &lib32_wine_pe /app/share/steam/compatibilitytools.d/Proton-GE/lib32/wine/i386-windows
-  libdir: /app/share/steam/compatibilitytools.d/Proton-GE/lib32
-  cflags: &optflags32 -O2 -pipe -march=nocona -mtune=core-avx2 -mfpmath=sse -fwrapv
-    -fno-strict-aliasing -mstackrealign
-  cflags-override: true
-  cxxflags: *optflags32
-  cxxflags-override: true
-
-x-proton-source: &proton_source files/proton/source.yaml
 
 cleanup:
   - '*.a'
@@ -414,57 +460,89 @@ modules:
       - *proton_source
 
 
-# TODO: build vkd3d against cross-compiled Vulkan-Loader instead of Wine vulkan lib
+  - name: vulkan-loader
+    subdir: Vulkan-Loader
+    buildsystem: cmake
+    build-options:
+      arch:
+        x86_64: *mingw-64-opts
+      config-opts:
+        - -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc
+        - -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-gcc
+        - -DINCLUDE_DIRECTORIES=/usr/lib/sdk/mingw-w64/x86_64-w64-mingw32/include /app/share/steam/compatibilitytools.d/Proton-GE/include
+        - -DCMAKE_CROSSCOMPILING=true
+        - -DVulkanHeaders_INCLUDE_DIR=/app/share/steam/compatibilitytools.d/Proton-GE/include
+        - -DCMAKE_BUILD_TYPE=plain
+        - -DCMAKE_SYSTEM_NAME=Windows
+        - -DCMAKE_SHARED_LIBRARY_PREFIX_C=
+        - -DCMAKE_IMPORT_LIBRARY_PREFIX_C=
+      prefix: /app/share/steam/compatibilitytools.d/Proton-GE/lib/vulkan-loader/prefix
+    post-install:
+      - mv -v ${FLATPAK_DEST}/lib/{vulkan-loader/prefix/bin/,}vulkan-1.dll
+    cleanup:
+      - /lib/vulkan-loader/prefix
+    config-opts: &vulkan-loader-config-opts
+      - -DUSE_MASM=OFF
+    sources:
+      - *proton_source
+
+  - name: vulkan-loader-32bit
+    subdir: Vulkan-Loader
+    buildsystem: cmake
+    build-options:
+      arch:
+        x86_64: *mingw-32-opts
+      config-opts:
+        - -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc
+        - -DCMAKE_CXX_COMPILER=i686-w64-mingw32-gcc
+        - -DINCLUDE_DIRECTORIES=/usr/lib/sdk/mingw-w64/i686-w64-mingw32/include /app/share/steam/compatibilitytools.d/Proton-GE/include
+        - -DCMAKE_CROSSCOMPILING=true
+        - -DVulkanHeaders_INCLUDE_DIR=/app/share/steam/compatibilitytools.d/Proton-GE/include
+        - -DCMAKE_BUILD_TYPE=plain
+        - -DCMAKE_SYSTEM_NAME=Windows
+        - -DCMAKE_SHARED_LIBRARY_PREFIX_C=
+        - -DCMAKE_IMPORT_LIBRARY_PREFIX_C=
+      prefix: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/vulkan-loader/prefix
+    post-install:
+      - mv -v ${FLATPAK_DEST}/lib32/{vulkan-loader/prefix/bin/,}vulkan-1.dll
+    cleanup:
+      - /lib32/vulkan-loader/prefix
+    config-opts: *vulkan-loader-config-opts
+    sources:
+      - *proton_source
+
 
   - name: vkd3d-wine
     subdir: vkd3d
     build-options:
       arch:
-        x86_64:
-          env:
-            WIDL: x86_64-w64-mingw32-widl
-      ldflags: >-
-        -L/run/build/vkd3d/wine/dlls/vulkan-1
-      ldflags-override: true
+        x86_64: *mingw-64-opts
       config-opts:
         - --host=x86_64-w64-mingw32
-      env:
-        CC: ccache x86_64-w64-mingw32-gcc
-        LD: x86_64-w64-mingw32-ld
       prefix: /app/share/steam/compatibilitytools.d/Proton-GE/lib/vkd3d/prefix
     config-opts: *vkd3d-config-opts
     post-install:
       - mv -v ${FLATPAK_DEST}/lib/vkd3d/{prefix/bin/,}libvkd3d-1.dll
       - mv -v ${FLATPAK_DEST}/lib/vkd3d/{prefix/bin/,}libvkd3d-shader-1.dll
-    sources: &vkd3d-sources
+    sources:
       - *proton_source
-      - type: shell
-        commands:
-          - install -D $FLATPAK_LIBDIR_WINE_PE/vulkan-1.dll -t wine/dlls/vulkan-1/
     cleanup:
       - /lib/vkd3d/prefix
 
   - name: vkd3d-wine-32bit
     subdir: vkd3d
     build-options:
-      ldflags: >-
-        -L/run/build/vkd3d-32bit/wine/dlls/vulkan-1
-      ldflags-override: true
+      arch:
+        x86_64: *mingw-32-opts
       config-opts:
         - --host=i686-w64-mingw32
-      env:
-        CC: ccache i686-w64-mingw32-gcc
-        LD: i686-w64-mingw32-ld
-        # XXX: build-options.arch.*.env overrides build-options.env
-        # so we can't easily use compat_i386_opts anchor here
-        FLATPAK_LIBDIR_WINE_PE: *lib32_wine_pe
-        WIDL: i686-w64-mingw32-widl
       prefix: /app/share/steam/compatibilitytools.d/Proton-GE/lib32/vkd3d/prefix
     config-opts: *vkd3d-config-opts
     post-install:
       - mv -v ${FLATPAK_DEST}/lib32/vkd3d/{prefix/bin/,}libvkd3d-1.dll
       - mv -v ${FLATPAK_DEST}/lib32/vkd3d/{prefix/bin/,}libvkd3d-shader-1.dll
-    sources: *vkd3d-sources
+    sources:
+      - *proton_source
     cleanup:
       - /lib32/vkd3d/prefix
 
@@ -473,7 +551,7 @@ modules:
     subdir: vkd3d-proton
     buildsystem: meson
     build-options:
-      ldflags: &mingw-ldflags ''
+      ldflags: *mingw-ldflags-64
       ldflags-override: true
       config-opts:
         - --cross-file=../build-win64.txt
@@ -505,7 +583,7 @@ modules:
     subdir: vkd3d-proton
     buildsystem: meson
     build-options:
-      ldflags: *mingw-ldflags
+      ldflags: *mingw-ldflags-32
       ldflags-override: true
       config-opts:
         - --cross-file=../build-win32.txt
@@ -523,8 +601,8 @@ modules:
     subdir: dxvk
     buildsystem: meson
     build-options:
-      ldflags: *mingw-ldflags
-      ldflags-override: true
+      arch:
+        x86_64: *mingw-64-opts
       config-opts:
         - --cross-file=../build-win64.txt
         - --cross-file=../meson-ccache-mingw64.txt
@@ -555,8 +633,8 @@ modules:
     subdir: dxvk
     buildsystem: meson
     build-options:
-      ldflags: *mingw-ldflags
-      ldflags-override: true
+      arch:
+        x86_64: *mingw-32-opts
       config-opts:
         - --cross-file=../build-win32.txt
         - --cross-file=../meson-ccache-mingw32.txt
@@ -573,7 +651,7 @@ modules:
     subdir: dxvk-nvapi
     buildsystem: meson
     build-options:
-      ldflags: ''
+      ldflags: *mingw-ldflags-64
       ldflags-override: true
       config-opts:
         - --cross-file=../build-win64.txt
@@ -599,7 +677,7 @@ modules:
     subdir: dxvk-nvapi
     buildsystem: meson
     build-options:
-      ldflags: ''
+      ldflags: *mingw-ldflags-32
       ldflags-override: true
       config-opts:
         - --cross-file=../build-win32.txt

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -99,6 +99,7 @@ modules:
           env:
             WIDL: x86_64-w64-mingw32-widl
     config-opts: &vkd3d-config-opts
+      - --enable-silent-rules
       - --disable-doxygen-doc
       - --disable-tests
       - --disable-demos


### PR DESCRIPTION
Contains a lot already present in #150. I had to rework a lot of the MinGW-related building. Would've turned out much prettier if *libyaml* (and by extension flatpak-builder) supported the YAML 1.1 merge key, alas this has turned into a *lot* of anchors.

I also had to ditch 1968c4d as it fails to build due to *skbuild* missing and I have a newfound hatred of cmake, though judging by the search results in regards to cross-compilation I don't seem to be the only one.…

Either way, I still had that weird Proton 8-1 build lying around that *somehow* managed to build at some point, but which I haven't been able to reproduce, which makes me *very* interested in the outcome of the CI job of this, as my environment clearly managed to defy the isolation and sandboxing that it should've had.